### PR TITLE
(chore) Remove Prometheus scrape annotations from Temporal pods to avoid duplicate scraping (with headless Service annotated also)

### DIFF
--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -31,11 +31,6 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/server-sprig-configmap.yaml") $ | sha256sum }}-{{ include (print $.Template.BasePath "/server-dockerize-configmap.yaml") $ | sha256sum }}
-        {{- if (dig "metrics" "annotations" "enabled" $.Values.server.metrics.annotations.enabled $serviceValues) }}
-        prometheus.io/job: {{ $.Chart.Name }}-{{ $service }}
-        prometheus.io/scrape: 'true'
-        prometheus.io/port: '9090'
-        {{- end }}
         {{- include "temporal.resourceAnnotations" (list $ $service "pod") | nindent 8 }}
       labels:
         {{- include "temporal.resourceLabels" (list $ $service "pod") | nindent 8 }}
@@ -141,7 +136,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "temporal.persistence.secretName" (list $ "secondaryVisibility") }}
                   key: {{ include "temporal.persistence.secretKey" (list $ "secondaryVisibility") }}
-            {{- end }}      
+            {{- end }}
             {{- end }}
           {{- if and (hasKey $.Values.server "internalFrontend") $.Values.server.internalFrontend.enabled }}
             - name: USE_INTERNAL_FRONTEND

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -37,8 +37,8 @@ server:
   deploymentStrategy:
     type: RollingUpdate
   metrics:
-    # Annotate pods directly with Prometheus annotations.
-    # Use this if you installed Prometheus from a Helm chart.
+    # Prometheus scrape annotations on the per-service headless Services (the pods are
+    # deliberately NOT annotated — annotating both doubles scraped sample volume).
     annotations:
       enabled: true
     # Additional tags to be added to Prometheus metrics


### PR DESCRIPTION
The [Service scrape annotations](https://github.com/fairmoney/temporal-helm-charts/blob/82b748f01974c56f4cb443987c8ba02d761f1efb/charts/temporal/templates/server-service.yaml#L70-L75) are enough.